### PR TITLE
feature/fix-diagonal-wins

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -20,7 +20,7 @@ class Game {
         var string2 = p2Moves.sort();
         var sorted1 = string1.toString();
         var sorted2 = string2.toString();
-        var winningArray = ['a1,a2,a3', 'b1,b2,b3', 'c1,c2,c3', 'a1,b1,c1', 'a2,b2,c2', 'a3,b3,c3', 'a1,b2,c3', 'a3,b2,c1'];
+        var winningArray = ['a1,a2,a3', 'b1,b2,b3', 'c1,c2,c3', 'a1,b1,c1', 'a2,b2,c2', 'a3,b3,c3', 'a1,b2,c3', 'a3,b2,c1', 'a1,b2,c1,c3', 'a3,a1,b2,c1'];
         for (var i = 0; i < winningArray.length; i++){
             if (sorted1.includes(winningArray[i])){
                 player1Win();


### PR DESCRIPTION
#### What does this PR do?
Adds two additional strings to the winningArray to accommodate specific diagonal win scenarios where in which two squares from the same row are selected before the diagonal is complete.

#### Where should the reviewer start?
Line 23 of game.js.

#### How should this PR be manually tested?
Test by playing multiple games as each player and seeing if any wins are not detected.

#### Any additional considerations?
Right now the squares do not disable on a win, but I plan on fixing that with the next PR.
