### PR TITLE
feature/disable-squares

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,15 +19,15 @@
     <section class="game-board">
         <h1 class="announcement">❌'s TURN!</h1>
         <article class="game-grid">
-            <p class="square" id="c1"></p>
-            <p class="square" id="c2"></p>
-            <p class="square" id="c3"></p>
-            <p class="square" id="b1"></p>
-            <p class="square" id="b2"></p>
-            <p class="square" id="b3"></p>
-            <p class="square" id="a1"></p>
-            <p class="square" id="a2"></p>
-            <p class="square" id="a3"></p>
+            <button class="square" id="c1"></button>
+            <button class="square" id="c2"></button>
+            <button class="square" id="c3"></button>
+            <button class="square" id="b1"></button>
+            <button class="square" id="b2"></button>
+            <button class="square" id="b3"></button>
+            <button class="square" id="a1"></button>
+            <button class="square" id="a2"></button>
+            <button class="square" id="a3"></button>
         </article>
     </section>
     <script src="src/player.js"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -32,15 +32,29 @@ function timeout(ms) {
 }
 
 async function clearBoard(){
+    disableSquares();
     await timeout(1000);
+    enableSquares();
     squares.forEach(node => {
-        node.innerText = '  ';
+        node.innerText = '';
     })
     if(game.currentPlayer === 'p1'){
         announcement.innerText = "❌'s TURN!"
     }else{
         announcement.innerText = "⭕️'s TURN!"
     }    
+}
+
+function disableSquares(){
+    squares.forEach(node => {
+        node.disabled = true;
+    })
+}
+
+function enableSquares(){
+    squares.forEach(node => {
+        node.disabled = false;
+    })
 }
 
 function showPlayerOne(p1Moves){

--- a/styles.css
+++ b/styles.css
@@ -67,6 +67,9 @@ html, body {
 }
 
 .square {
+    background-color: inherit;
+    border: inherit;
+    outline: none;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
#### What does this PR do?
Change square elements to buttons to allow them to be disabled during timeout between winning and resetting the board. Add disableSquares and enableSquares function that are invoked before and after the timeout, respectively. 

#### Where should the reviewer start?
Start at line 22-30 of index.html.  Please note that some additional CSS styling was added to the square class to accommodate the default properties of buttons.  Lines 48-59 of main.js contain the two functions that diable and enable the button.

#### How should this PR be manually tested?
Play multiple games as either player and try to select another button during timeout after win. This also prevents the player from switching during that timeout. So if X wins, O plays first in the next game, and vice versa.

#### Any additional considerations?
I added these two functions to avoid styling in main.js, but the disable feature is a native property to the button element, so it may be as simple as toggling the disable property in the clearBoard function. Something to consider.
