### PR TITLE
feature/draw-bug-fix

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -25,6 +25,7 @@ class Game {
                 this.currentPlayer.saveWinsToStorage();
                 showWin(this.currentPlayer.token)
                 this.newGame(this.player1, this.player2);
+                return;
             }else{
                 this.findDraw();
             };


### PR DESCRIPTION
#### What does this PR do?
Add 'return' to end of finWin function so full board wins are not declared as draw. This prevents the function from running the 'declareDraw' function if there is a winner.

#### Where should the reviewer start?
Line 28 of game.js.

#### How should this PR be manually tested?
Starting from any square, build a box around the parameter, alternating players, then select the last box. A winner should be declared.

#### Any additional considerations?
I think I'm done now.
